### PR TITLE
Update mask when any part of the input shape changes.

### DIFF
--- a/models/partialconv2d.py
+++ b/models/partialconv2d.py
@@ -36,14 +36,14 @@ class PartialConv2d(nn.Conv2d):
             
         self.slide_winsize = self.weight_maskUpdater.shape[1] * self.weight_maskUpdater.shape[2] * self.weight_maskUpdater.shape[3]
 
-        self.last_size = (None, None)
+        self.last_size = (None, None, None, None)
         self.update_mask = None
         self.mask_ratio = None
 
     def forward(self, input, mask_in=None):
-        
-        if mask_in is not None or self.last_size != (input.data.shape[2], input.data.shape[3]):
-            self.last_size = (input.data.shape[2], input.data.shape[3])
+        assert len(input.shape) == 4
+        if mask_in is not None or self.last_size != tuple(input.shape):
+            self.last_size = tuple(input.shape)
 
             with torch.no_grad():
                 if self.weight_maskUpdater.type() != input.type():

--- a/models/partialconv3d.py
+++ b/models/partialconv3d.py
@@ -36,14 +36,14 @@ class PartialConv3d(nn.Conv3d):
             
         self.slide_winsize = self.weight_maskUpdater.shape[1] * self.weight_maskUpdater.shape[2] * self.weight_maskUpdater.shape[3]  * self.weight_maskUpdater.shape[4]
 
-        self.last_size = (None, None, None)
+        self.last_size = (None, None, None, None, None)
         self.update_mask = None
         self.mask_ratio = None
 
     def forward(self, input, mask_input=None):
-        
-        if mask_input is not None or self.last_size != (input.data.shape[2], input.data.shape[3], input.data.shape[4]):
-            self.last_size = (input.data.shape[2], input.data.shape[3], input.data.shape[4])
+        assert len(input.shape) == 5 
+        if mask_input is not None or self.last_size != tuple(input.shape):
+            self.last_size = tuple(input.shape)
 
             with torch.no_grad():
                 if self.weight_maskUpdater.type() != input.type():

--- a/models/partialconv3d.py
+++ b/models/partialconv3d.py
@@ -41,7 +41,7 @@ class PartialConv3d(nn.Conv3d):
         self.mask_ratio = None
 
     def forward(self, input, mask_input=None):
-        assert len(input.shape) == 5 
+        assert len(input.shape) == 5
         if mask_input is not None or self.last_size != tuple(input.shape):
             self.last_size = tuple(input.shape)
 


### PR DESCRIPTION
In the current implementation, the mask would only be updated when the input spatial shape [(H,W) and (D,H,W) in 2d and 3d PartialConv respectively) changed.

Thus, the code breaks at [partialconv2d.py:76](https://github.com/NVIDIA/partialconv/blob/master/models/partialconv2d.py#L76) when the batch size changes but the spatial size stays the same, because `self.mask_ratio` hasn't been update and has the batch size that's inconsistent with the current batch size.

I've added the following:
* assert statements to check the dimensions of the input shape (4- and 5-D tensors for 2d and 3d conv respectively)
* switched the behavior of self.last_size to remember the size of the whole input, not just its spatial size

Thus, when the batch size changes -- the mask will be updated.